### PR TITLE
Update pulumi-terraform to f083d8ce44

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da
-	github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca
+	github.com/pulumi/pulumi-terraform v0.18.4-0.20190708212248-f083d8ce442f
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
 	github.com/terraform-providers/terraform-provider-newrelic v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/pulumi/pulumi-terraform v0.18.3 h1:DHpETa+TWnthH9Sw3bHS+HxSgidB1cASkV
 github.com/pulumi/pulumi-terraform v0.18.3/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca h1:Zj43rjNar4a6eBHLLHKWoXmew8vmW1vCLKSmgFHjB+g=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190708212248-f083d8ce442f h1:jQs/EoCZamSY/X+EZx/ACTkp3QKJMJbm5TX6vbKFkiY=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190708212248-f083d8ce442f/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [f083d8ce44](https://github.com/pulumi/pulumi-terraform/commit/f083d8ce442ffc04771a973e428c8dab5555df66), and re-runs code generation