### PR TITLE
fix newrelic type comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Fix comments on Alert Conditions API to be snake_case instead of camelCase
 
 ---
 

--- a/sdk/go/newrelic/alertCondition.go
+++ b/sdk/go/newrelic/alertCondition.go
@@ -96,48 +96,47 @@ type AlertCondition struct {
 	// A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
 	GcMetric pulumi.StringPtrOutput `pulumi:"gcMetric"`
 	// The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-	// * `apmAppMetric`
+	// * `apm_app_metric`
 	// * `apdex`
-	// * `errorPercentage`
-	// * `responseTimeBackground`
-	// * `responseTimeWeb`
-	// * `throughputBackground`
-	// * `throughputWeb`
-	// * `userDefined`
-	// * `apmJvmMetric`
-	// * `cpuUtilizationTime`
-	// * `deadlockedThreads`
-	// * `gcCpuTime`
-	// * `heapMemoryUsage`
-	// * `apmKtMetric`
+	// * `error_percentage`
+	// * `response_time_background`
+	// * `response_time_web`
+	// * `throughput_background`
+	// * `throughput_web`
+	// * `user_defined`
+	// * `apm_jvm_metric`
+	// * `cpu_utilization_time`
+	// * `deadlocked_threads`
+	// * `gc_cpu_time`
+	// * `heap_memory_usage`
+	// * `apm_kt_metric`
 	// * `apdex`
-	// * `errorCount`
-	// * `errorPercentage`
-	// * `responseTime`
+	// * `error_count`
+	// * `response_time`
 	// * `throughput`
-	// * `browserMetric`
-	// * `ajaxResponseTime`
-	// * `ajaxThroughput`
-	// * `domProcessing`
-	// * `endUserApdex`
+	// * `browser_metric`
+	// * `ajax_response_time`
+	// * `ajax_throughput`
+	// * `dom_processing`
+	// * `end_user_apdex`
 	// * `network`
-	// * `pageRendering`
-	// * `pageViewThroughput`
-	// * `pageViewsWithJsErrors`
-	// * `requestQueuing`
-	// * `totalPageLoad`
-	// * `userDefined`
-	// * `webApplication`
-	// * `mobileMetric`
+	// * `page_rendering`
+	// * `page_view_throughput`
+	// * `page_views_with_js_errors`
+	// * `request_queuing`
+	// * `total_page_load`
+	// * `user_defined`
+	// * `web_application`
+	// * `mobile_metric`
 	// * `database`
 	// * `images`
 	// * `json`
-	// * `mobileCrashRate`
-	// * `networkErrorPercentage`
+	// * `mobile_crash_rate`
+	// * `network_error_percentage`
 	// * `network`
-	// * `statusErrorPercentage`
-	// * `userDefined`
-	// * `viewLoading`
+	// * `status_error_percentage`
+	// * `user_defined`
+	// * `view_loading`
 	Metric pulumi.StringOutput `pulumi:"metric"`
 	// The title of the condition. Must be between 1 and 64 characters, inclusive.
 	Name pulumi.StringOutput `pulumi:"name"`
@@ -147,7 +146,7 @@ type AlertCondition struct {
 	RunbookUrl pulumi.StringPtrOutput `pulumi:"runbookUrl"`
 	// A list of terms for this condition. See Terms below for details.
 	Terms AlertConditionTermArrayOutput `pulumi:"terms"`
-	// The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+	// The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
 	Type pulumi.StringOutput `pulumi:"type"`
 	// A custom metric to be evaluated.
 	UserDefinedMetric pulumi.StringPtrOutput `pulumi:"userDefinedMetric"`
@@ -210,48 +209,48 @@ type alertConditionState struct {
 	// A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
 	GcMetric *string `pulumi:"gcMetric"`
 	// The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-	// * `apmAppMetric`
+	// * `apm_app_metric`
 	// * `apdex`
-	// * `errorPercentage`
-	// * `responseTimeBackground`
-	// * `responseTimeWeb`
-	// * `throughputBackground`
-	// * `throughputWeb`
-	// * `userDefined`
-	// * `apmJvmMetric`
-	// * `cpuUtilizationTime`
-	// * `deadlockedThreads`
-	// * `gcCpuTime`
-	// * `heapMemoryUsage`
-	// * `apmKtMetric`
+	// * `error_percentage`
+	// * `response_time_background`
+	// * `response_time_web`
+	// * `throughput_background`
+	// * `throughput_web`
+	// * `user_defined`
+	// * `apm_jvm_metric`
+	// * `cpu_utilization_time`
+	// * `deadlocked_threads`
+	// * `gc_cpu_time`
+	// * `heap_memory_usage`
+	// * `apm_kt_metric`
 	// * `apdex`
-	// * `errorCount`
-	// * `errorPercentage`
-	// * `responseTime`
+	// * `error_count`
+	// * `error_percentage`
+	// * `response_time`
 	// * `throughput`
-	// * `browserMetric`
-	// * `ajaxResponseTime`
-	// * `ajaxThroughput`
-	// * `domProcessing`
-	// * `endUserApdex`
+	// * `browser_metric`
+	// * `ajax_response_time`
+	// * `ajax_throughput`
+	// * `dom_processing`
+	// * `end_user_apdex`
 	// * `network`
-	// * `pageRendering`
-	// * `pageViewThroughput`
-	// * `pageViewsWithJsErrors`
-	// * `requestQueuing`
-	// * `totalPageLoad`
-	// * `userDefined`
-	// * `webApplication`
-	// * `mobileMetric`
+	// * `page_rendering`
+	// * `page_view_throughput`
+	// * `page_views_with_js_errors`
+	// * `request_queuing`
+	// * `total_page_load`
+	// * `user_defined`
+	// * `web_application`
+	// * `mobile_metric`
 	// * `database`
 	// * `images`
 	// * `json`
-	// * `mobileCrashRate`
-	// * `networkErrorPercentage`
+	// * `mobile_crash_rate`
+	// * `network_error_percentage`
 	// * `network`
-	// * `statusErrorPercentage`
-	// * `userDefined`
-	// * `viewLoading`
+	// * `status_error_percentage`
+	// * `user_defined`
+	// * `view_loading`
 	Metric *string `pulumi:"metric"`
 	// The title of the condition. Must be between 1 and 64 characters, inclusive.
 	Name *string `pulumi:"name"`
@@ -261,7 +260,7 @@ type alertConditionState struct {
 	RunbookUrl *string `pulumi:"runbookUrl"`
 	// A list of terms for this condition. See Terms below for details.
 	Terms []AlertConditionTerm `pulumi:"terms"`
-	// The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+	// The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
 	Type *string `pulumi:"type"`
 	// A custom metric to be evaluated.
 	UserDefinedMetric *string `pulumi:"userDefinedMetric"`
@@ -281,48 +280,48 @@ type AlertConditionState struct {
 	// A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
 	GcMetric pulumi.StringPtrInput
 	// The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-	// * `apmAppMetric`
+	// * `apm_app_metric`
 	// * `apdex`
-	// * `errorPercentage`
-	// * `responseTimeBackground`
-	// * `responseTimeWeb`
-	// * `throughputBackground`
-	// * `throughputWeb`
-	// * `userDefined`
-	// * `apmJvmMetric`
-	// * `cpuUtilizationTime`
-	// * `deadlockedThreads`
-	// * `gcCpuTime`
-	// * `heapMemoryUsage`
-	// * `apmKtMetric`
+	// * `error_percentage`
+	// * `response_time_background`
+	// * `response_time_web`
+	// * `throughput_background`
+	// * `throughput_web`
+	// * `user_defined`
+	// * `apm_jvm_metric`
+	// * `cpu_utilization_time`
+	// * `deadlocked_threads`
+	// * `gc_cpu_time`
+	// * `heap_memory_usage`
+	// * `apm_kt_metric`
 	// * `apdex`
-	// * `errorCount`
-	// * `errorPercentage`
-	// * `responseTime`
+	// * `error_count`
+	// * `error_percentage`
+	// * `response_time`
 	// * `throughput`
-	// * `browserMetric`
-	// * `ajaxResponseTime`
-	// * `ajaxThroughput`
-	// * `domProcessing`
-	// * `endUserApdex`
+	// * `browser_metric`
+	// * `ajax_response_time`
+	// * `ajax_throughput`
+	// * `dom_processing`
+	// * `end_user_apdex`
 	// * `network`
-	// * `pageRendering`
-	// * `pageViewThroughput`
-	// * `pageViewsWithJsErrors`
-	// * `requestQueuing`
-	// * `totalPageLoad`
-	// * `userDefined`
-	// * `webApplication`
-	// * `mobileMetric`
+	// * `page_rendering`
+	// * `page_view_throughput`
+	// * `page_views_with_js_errors`
+	// * `request_queuing`
+	// * `total_page_load`
+	// * `user_defined`
+	// * `web_application`
+	// * `mobile_metric`
 	// * `database`
 	// * `images`
 	// * `json`
-	// * `mobileCrashRate`
-	// * `networkErrorPercentage`
+	// * `mobile_crash_rate`
+	// * `network_error_percentage`
 	// * `network`
-	// * `statusErrorPercentage`
-	// * `userDefined`
-	// * `viewLoading`
+	// * `status_error_percentage`
+	// * `user_defined`
+	// * `view_loading`
 	Metric pulumi.StringPtrInput
 	// The title of the condition. Must be between 1 and 64 characters, inclusive.
 	Name pulumi.StringPtrInput
@@ -332,7 +331,7 @@ type AlertConditionState struct {
 	RunbookUrl pulumi.StringPtrInput
 	// A list of terms for this condition. See Terms below for details.
 	Terms AlertConditionTermArrayInput
-	// The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+	// The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
 	Type pulumi.StringPtrInput
 	// A custom metric to be evaluated.
 	UserDefinedMetric pulumi.StringPtrInput
@@ -356,48 +355,48 @@ type alertConditionArgs struct {
 	// A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
 	GcMetric *string `pulumi:"gcMetric"`
 	// The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-	// * `apmAppMetric`
+	// * `apm_app_metric`
 	// * `apdex`
-	// * `errorPercentage`
-	// * `responseTimeBackground`
-	// * `responseTimeWeb`
-	// * `throughputBackground`
-	// * `throughputWeb`
-	// * `userDefined`
-	// * `apmJvmMetric`
-	// * `cpuUtilizationTime`
-	// * `deadlockedThreads`
-	// * `gcCpuTime`
-	// * `heapMemoryUsage`
-	// * `apmKtMetric`
+	// * `error_percentage`
+	// * `response_time_background`
+	// * `response_time_web`
+	// * `throughput_background`
+	// * `throughput_web`
+	// * `user_defined`
+	// * `apm_jvm_metric`
+	// * `cpu_utilization_time`
+	// * `deadlocked_threads`
+	// * `gc_cpu_time`
+	// * `heap_memory_usage`
+	// * `apm_kt_metric`
 	// * `apdex`
-	// * `errorCount`
-	// * `errorPercentage`
-	// * `responseTime`
+	// * `error_count`
+	// * `error_percentage`
+	// * `response_time`
 	// * `throughput`
-	// * `browserMetric`
-	// * `ajaxResponseTime`
-	// * `ajaxThroughput`
-	// * `domProcessing`
-	// * `endUserApdex`
+	// * `browser_metric`
+	// * `ajax_response_time`
+	// * `ajax_throughput`
+	// * `dom_processing`
+	// * `end_user_apdex`
 	// * `network`
-	// * `pageRendering`
-	// * `pageViewThroughput`
-	// * `pageViewsWithJsErrors`
-	// * `requestQueuing`
-	// * `totalPageLoad`
-	// * `userDefined`
-	// * `webApplication`
-	// * `mobileMetric`
+	// * `page_rendering`
+	// * `page_view_throughput`
+	// * `page_views_with_js_errors`
+	// * `request_queuing`
+	// * `total_page_load`
+	// * `user_defined`
+	// * `web_application`
+	// * `mobile_metric`
 	// * `database`
 	// * `images`
 	// * `json`
-	// * `mobileCrashRate`
-	// * `networkErrorPercentage`
+	// * `mobile_crash_rate`
+	// * `network_error_percentage`
 	// * `network`
-	// * `statusErrorPercentage`
-	// * `userDefined`
-	// * `viewLoading`
+	// * `status_error_percentage`
+	// * `user_defined`
+	// * `view_loading`
 	Metric string `pulumi:"metric"`
 	// The title of the condition. Must be between 1 and 64 characters, inclusive.
 	Name *string `pulumi:"name"`
@@ -407,7 +406,7 @@ type alertConditionArgs struct {
 	RunbookUrl *string `pulumi:"runbookUrl"`
 	// A list of terms for this condition. See Terms below for details.
 	Terms []AlertConditionTerm `pulumi:"terms"`
-	// The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+	// The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
 	Type string `pulumi:"type"`
 	// A custom metric to be evaluated.
 	UserDefinedMetric *string `pulumi:"userDefinedMetric"`
@@ -428,48 +427,47 @@ type AlertConditionArgs struct {
 	// A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
 	GcMetric pulumi.StringPtrInput
 	// The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-	// * `apmAppMetric`
+	// * `apm_app_metric`
 	// * `apdex`
-	// * `errorPercentage`
-	// * `responseTimeBackground`
-	// * `responseTimeWeb`
-	// * `throughputBackground`
-	// * `throughputWeb`
-	// * `userDefined`
-	// * `apmJvmMetric`
-	// * `cpuUtilizationTime`
-	// * `deadlockedThreads`
-	// * `gcCpuTime`
-	// * `heapMemoryUsage`
-	// * `apmKtMetric`
+	// * `error_percentage`
+	// * `response_time_background`
+	// * `response_time_web`
+	// * `throughput_background`
+	// * `throughput_web`
+	// * `user_defined`
+	// * `apm_jvm_metric`
+	// * `cpu_utilization_time`
+	// * `deadlocked_threads`
+	// * `gc_cpu_time`
+	// * `heap_memory_usage`
+	// * `apm_kt_metric`
 	// * `apdex`
-	// * `errorCount`
-	// * `errorPercentage`
-	// * `responseTime`
+	// * `error_count`
+	// * `response_time`
 	// * `throughput`
-	// * `browserMetric`
-	// * `ajaxResponseTime`
-	// * `ajaxThroughput`
-	// * `domProcessing`
-	// * `endUserApdex`
+	// * `browser_metric`
+	// * `ajax_response_time`
+	// * `ajax_throughput`
+	// * `dom_processing`
+	// * `end_user_apdex`
 	// * `network`
-	// * `pageRendering`
-	// * `pageViewThroughput`
-	// * `pageViewsWithJsErrors`
-	// * `requestQueuing`
-	// * `totalPageLoad`
-	// * `userDefined`
-	// * `webApplication`
-	// * `mobileMetric`
+	// * `page_rendering`
+	// * `page_view_throughput`
+	// * `page_views_with_js_errors`
+	// * `request_queuing`
+	// * `total_page_load`
+	// * `user_defined`
+	// * `web_application`
+	// * `mobile_metric`
 	// * `database`
 	// * `images`
 	// * `json`
-	// * `mobileCrashRate`
-	// * `networkErrorPercentage`
+	// * `mobile_crash_rate`
+	// * `network_error_percentage`
 	// * `network`
-	// * `statusErrorPercentage`
-	// * `userDefined`
-	// * `viewLoading`
+	// * `status_error_percentage`
+	// * `user_defined`
+	// * `view_loading`
 	Metric pulumi.StringInput
 	// The title of the condition. Must be between 1 and 64 characters, inclusive.
 	Name pulumi.StringPtrInput
@@ -479,7 +477,7 @@ type AlertConditionArgs struct {
 	RunbookUrl pulumi.StringPtrInput
 	// A list of terms for this condition. See Terms below for details.
 	Terms AlertConditionTermArrayInput
-	// The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+	// The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
 	Type pulumi.StringInput
 	// A custom metric to be evaluated.
 	UserDefinedMetric pulumi.StringPtrInput

--- a/sdk/nodejs/alertCondition.ts
+++ b/sdk/nodejs/alertCondition.ts
@@ -102,48 +102,47 @@ export class AlertCondition extends pulumi.CustomResource {
     public readonly gcMetric!: pulumi.Output<string | undefined>;
     /**
      * The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-     * * `apmAppMetric`
+     * * `apm_app_metric`
      * * `apdex`
-     * * `errorPercentage`
-     * * `responseTimeBackground`
-     * * `responseTimeWeb`
-     * * `throughputBackground`
-     * * `throughputWeb`
-     * * `userDefined`
-     * * `apmJvmMetric`
-     * * `cpuUtilizationTime`
-     * * `deadlockedThreads`
-     * * `gcCpuTime`
-     * * `heapMemoryUsage`
-     * * `apmKtMetric`
+     * * `error_percentage`
+     * * `response_time_background`
+     * * `response_time_web`
+     * * `throughput_background`
+     * * `throughput_web`
+     * * `user_defined`
+     * * `apm_jvm_metric`
+     * * `cpu_utilization_time`
+     * * `deadlocked_threads`
+     * * `gc_cpu_time`
+     * * `heap_memory_usage`
+     * * `apm_kt_metric`
      * * `apdex`
-     * * `errorCount`
-     * * `errorPercentage`
-     * * `responseTime`
+     * * `error_count`
+     * * `response_time`
      * * `throughput`
-     * * `browserMetric`
-     * * `ajaxResponseTime`
-     * * `ajaxThroughput`
-     * * `domProcessing`
-     * * `endUserApdex`
+     * * `browser_metric`
+     * * `ajax_response_time`
+     * * `ajax_throughput`
+     * * `dom_processing`
+     * * `end_user_apdex`
      * * `network`
-     * * `pageRendering`
-     * * `pageViewThroughput`
-     * * `pageViewsWithJsErrors`
-     * * `requestQueuing`
-     * * `totalPageLoad`
-     * * `userDefined`
-     * * `webApplication`
-     * * `mobileMetric`
+     * * `page_rendering`
+     * * `page_view_throughput`
+     * * `page_views_with_js_errors`
+     * * `request_queuing`
+     * * `total_page_load`
+     * * `user_defined`
+     * * `web_application`
+     * * `mobile_metric`
      * * `database`
      * * `images`
      * * `json`
-     * * `mobileCrashRate`
-     * * `networkErrorPercentage`
+     * * `mobile_crash_rate`
+     * * `network_error_percentage`
      * * `network`
-     * * `statusErrorPercentage`
-     * * `userDefined`
-     * * `viewLoading`
+     * * `status_error_percentage`
+     * * `user_defined`
+     * * `view_loading`
      */
     public readonly metric!: pulumi.Output<string>;
     /**
@@ -163,7 +162,7 @@ export class AlertCondition extends pulumi.CustomResource {
      */
     public readonly terms!: pulumi.Output<outputs.AlertConditionTerm[]>;
     /**
-     * The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+     * The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
      */
     public readonly type!: pulumi.Output<string>;
     /**
@@ -265,48 +264,47 @@ export interface AlertConditionState {
     readonly gcMetric?: pulumi.Input<string>;
     /**
      * The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-     * * `apmAppMetric`
+     * * `apm_app_metric`
      * * `apdex`
-     * * `errorPercentage`
-     * * `responseTimeBackground`
-     * * `responseTimeWeb`
-     * * `throughputBackground`
-     * * `throughputWeb`
-     * * `userDefined`
-     * * `apmJvmMetric`
-     * * `cpuUtilizationTime`
-     * * `deadlockedThreads`
-     * * `gcCpuTime`
-     * * `heapMemoryUsage`
-     * * `apmKtMetric`
+     * * `error_percentage`
+     * * `response_time_background`
+     * * `response_time_web`
+     * * `throughput_background`
+     * * `throughput_web`
+     * * `user_defined`
+     * * `apm_jvm_metric`
+     * * `cpu_utilization_time`
+     * * `deadlocked_threads`
+     * * `gc_cpu_time`
+     * * `heap_memory_usage`
+     * * `apm_kt_metric`
      * * `apdex`
-     * * `errorCount`
-     * * `errorPercentage`
-     * * `responseTime`
+     * * `error_count`
+     * * `response_time`
      * * `throughput`
-     * * `browserMetric`
-     * * `ajaxResponseTime`
-     * * `ajaxThroughput`
-     * * `domProcessing`
-     * * `endUserApdex`
+     * * `browser_metric`
+     * * `ajax_response_time`
+     * * `ajax_throughput`
+     * * `dom_processing`
+     * * `end_user_apdex`
      * * `network`
-     * * `pageRendering`
-     * * `pageViewThroughput`
-     * * `pageViewsWithJsErrors`
-     * * `requestQueuing`
-     * * `totalPageLoad`
-     * * `userDefined`
-     * * `webApplication`
-     * * `mobileMetric`
+     * * `page_rendering`
+     * * `page_view_throughput`
+     * * `page_views_with_js_errors`
+     * * `request_queuing`
+     * * `total_page_load`
+     * * `user_defined`
+     * * `web_application`
+     * * `mobile_metric`
      * * `database`
      * * `images`
      * * `json`
-     * * `mobileCrashRate`
-     * * `networkErrorPercentage`
+     * * `mobile_crash_rate`
+     * * `network_error_percentage`
      * * `network`
-     * * `statusErrorPercentage`
-     * * `userDefined`
-     * * `viewLoading`
+     * * `status_error_percentage`
+     * * `user_defined`
+     * * `view_loading`
      */
     readonly metric?: pulumi.Input<string>;
     /**
@@ -326,7 +324,7 @@ export interface AlertConditionState {
      */
     readonly terms?: pulumi.Input<pulumi.Input<inputs.AlertConditionTerm>[]>;
     /**
-     * The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+     * The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
      */
     readonly type?: pulumi.Input<string>;
     /**
@@ -365,48 +363,47 @@ export interface AlertConditionArgs {
     readonly gcMetric?: pulumi.Input<string>;
     /**
      * The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
-     * * `apmAppMetric`
+     * * `apm_app_metric`
      * * `apdex`
-     * * `errorPercentage`
-     * * `responseTimeBackground`
-     * * `responseTimeWeb`
-     * * `throughputBackground`
-     * * `throughputWeb`
-     * * `userDefined`
-     * * `apmJvmMetric`
-     * * `cpuUtilizationTime`
-     * * `deadlockedThreads`
-     * * `gcCpuTime`
-     * * `heapMemoryUsage`
-     * * `apmKtMetric`
+     * * `error_percentage`
+     * * `response_time_background`
+     * * `response_time_web`
+     * * `throughput_background`
+     * * `throughput_web`
+     * * `user_defined`
+     * * `apm_jvm_metric`
+     * * `cpu_utilization_time`
+     * * `deadlocked_threads`
+     * * `gc_cpu_time`
+     * * `heap_memory_usage`
+     * * `apm_kt_metric`
      * * `apdex`
-     * * `errorCount`
-     * * `errorPercentage`
-     * * `responseTime`
+     * * `error_count`
+     * * `response_time`
      * * `throughput`
-     * * `browserMetric`
-     * * `ajaxResponseTime`
-     * * `ajaxThroughput`
-     * * `domProcessing`
-     * * `endUserApdex`
+     * * `browser_metric`
+     * * `ajax_response_time`
+     * * `ajax_throughput`
+     * * `dom_processing`
+     * * `end_user_apdex`
      * * `network`
-     * * `pageRendering`
-     * * `pageViewThroughput`
-     * * `pageViewsWithJsErrors`
-     * * `requestQueuing`
-     * * `totalPageLoad`
-     * * `userDefined`
-     * * `webApplication`
-     * * `mobileMetric`
+     * * `page_rendering`
+     * * `page_view_throughput`
+     * * `page_views_with_js_errors`
+     * * `request_queuing`
+     * * `total_page_load`
+     * * `user_defined`
+     * * `web_application`
+     * * `mobile_metric`
      * * `database`
      * * `images`
      * * `json`
-     * * `mobileCrashRate`
-     * * `networkErrorPercentage`
+     * * `mobile_crash_rate`
+     * * `network_error_percentage`
      * * `network`
-     * * `statusErrorPercentage`
-     * * `userDefined`
-     * * `viewLoading`
+     * * `status_error_percentage`
+     * * `user_defined`
+     * * `view_loading`
      */
     readonly metric: pulumi.Input<string>;
     /**
@@ -426,7 +423,7 @@ export interface AlertConditionArgs {
      */
     readonly terms: pulumi.Input<pulumi.Input<inputs.AlertConditionTerm>[]>;
     /**
-     * The type of condition. One of: `apmAppMetric`, `apmJvmMetric`, `apmKtMetric`, `browserMetric`, `mobileMetric`
+     * The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
      */
     readonly type: pulumi.Input<string>;
     /**


### PR DESCRIPTION
Changes the comments to be snake_case instead of camelCase. See: https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names/

using camelCase will result in a runtime errors on `pulumi up`. For example:

![image](https://user-images.githubusercontent.com/3690566/122093370-e0450780-cdbf-11eb-846f-13257b6edd90.png)
Hover text for `type` suggests camelCase (same for the `metric` property), but

```
const highErrorsAlertCondition = new newrelic.AlertCondition(
  "high-errors",
  {
    name: "high-errors",
    policyId: alertPolicy.then((x) => Number(x.id)),
    type: "apmAppMetric",
    entities: [app.then((app) => app.applicationId)],
    metric: "error_percentage",
    conditionScope: "application",
    terms: [
      {
        duration: 5,
        operator: "above",
        priority: "critical",
        threshold: 0.05,
        timeFunction: "all",
      },
    ],
  },
  { provider }
)
```

Results in the errors:

```
error: newrelic:index/alertCondition:AlertCondition resource 'high-errors' has a problem: expected type to be one of [apm_jvm_metric apm_kt_metric browser_metric mobile_metric servers_metric apm_app_metric], got apmAppMetric

error: 422 response returned: Metric must be one of the following: `apdex`, `error_percentage`, `response_time_web`, `response_time_background`, `throughput_web`, `throughput_background`, `user_defined`.
```